### PR TITLE
Fix bug with adding activities

### DIFF
--- a/src/main/java/hobbylist/model/activity/Activity.java
+++ b/src/main/java/hobbylist/model/activity/Activity.java
@@ -57,7 +57,9 @@ public class Activity {
         }
 
         return otherActivity != null
-                && otherActivity.getName().equals(getName());
+                && otherActivity.getName().equals(getName())
+                && otherActivity.getDescription().equals(getDescription())
+                && otherActivity.getTags().equals(getTags());
     }
 
     /**

--- a/src/test/data/JsonSerializableHobbyListTest/duplicateActivityHobbyList.json
+++ b/src/test/data/JsonSerializableHobbyListTest/duplicateActivityHobbyList.json
@@ -5,6 +5,7 @@
     "tagged": [ "friends" ]
   }, {
     "name": "Alice Pauline",
-    "description": "4th street"
+    "description": "123, Jurong West Ave 6, #08-111",
+    "tagged": [ "friends" ]
   } ]
 }

--- a/src/test/java/hobbylist/model/DescriptionBookTest.java
+++ b/src/test/java/hobbylist/model/DescriptionBookTest.java
@@ -1,7 +1,5 @@
 package hobbylist.model;
 
-import static hobbylist.logic.commands.CommandTestUtil.VALID_DESCRIPTION_BOXING;
-import static hobbylist.logic.commands.CommandTestUtil.VALID_TAG_ENTERTAINMENT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -45,8 +43,7 @@ public class DescriptionBookTest {
     @Test
     public void resetData_withDuplicateActivity_throwsDuplicateActivityException() {
         // Two activities with the same identity fields
-        Activity editedA = new ActivityBuilder(TypicalActivities.ACTIVITY_A).withDescription(VALID_DESCRIPTION_BOXING)
-                .withTags(VALID_TAG_ENTERTAINMENT)
+        Activity editedA = new ActivityBuilder(TypicalActivities.ACTIVITY_A)
                 .build();
         List<Activity> newActivities = Arrays.asList(TypicalActivities.ACTIVITY_A, editedA);
         HobbyListStub newData = new HobbyListStub(newActivities);
@@ -73,8 +70,7 @@ public class DescriptionBookTest {
     @Test
     public void hasActivity_activityWithSameIdentityFieldsInHobbyList_returnsTrue() {
         hobbyList.addActivity(TypicalActivities.ACTIVITY_A);
-        Activity editedA = new ActivityBuilder(TypicalActivities.ACTIVITY_A).withDescription(VALID_DESCRIPTION_BOXING)
-                .withTags(VALID_TAG_ENTERTAINMENT)
+        Activity editedA = new ActivityBuilder(TypicalActivities.ACTIVITY_A)
                 .build();
         assertTrue(hobbyList.hasActivity(editedA));
     }

--- a/src/test/java/hobbylist/model/activity/ActivityTest.java
+++ b/src/test/java/hobbylist/model/activity/ActivityTest.java
@@ -28,10 +28,10 @@ public class ActivityTest {
         // null -> returns false
         assertFalse(TypicalActivities.ACTIVITY_A.isSameActivity(null));
 
-        // same name, all other attributes different -> returns true
+        // same name, all other attributes different -> returns false
         Activity editedA = new ActivityBuilder(TypicalActivities.ACTIVITY_A)
                 .withDescription(VALID_DESCRIPTION_BOXING).withTags(VALID_TAG_ENTERTAINMENT).build();
-        assertTrue(TypicalActivities.ACTIVITY_A.isSameActivity(editedA));
+        assertFalse(TypicalActivities.ACTIVITY_A.isSameActivity(editedA));
 
         // different name, all other attributes same -> returns false
         editedA = new ActivityBuilder(TypicalActivities.ACTIVITY_A).withName(VALID_NAME_BOXING).build();
@@ -46,6 +46,10 @@ public class ActivityTest {
         String nameWithTrailingSpaces = VALID_NAME_BOXING + " ";
         editedB = new ActivityBuilder(TypicalActivities.BOXING).withName(nameWithTrailingSpaces).build();
         assertFalse(TypicalActivities.BOXING.isSameActivity(editedB));
+
+        // name, description and tags are all the same -> returns true
+        editedA = new ActivityBuilder((TypicalActivities.ACTIVITY_A)).build();
+        assertTrue(TypicalActivities.ACTIVITY_A.isSameActivity(editedA));
     }
 
     @Test

--- a/src/test/java/hobbylist/model/activity/ActivityTest.java
+++ b/src/test/java/hobbylist/model/activity/ActivityTest.java
@@ -33,6 +33,16 @@ public class ActivityTest {
                 .withDescription(VALID_DESCRIPTION_BOXING).withTags(VALID_TAG_ENTERTAINMENT).build();
         assertFalse(TypicalActivities.ACTIVITY_A.isSameActivity(editedA));
 
+        // same name, description different -> returns false
+        editedA = new ActivityBuilder(TypicalActivities.ACTIVITY_A)
+                .withDescription(VALID_DESCRIPTION_BOXING).build();
+        assertFalse(TypicalActivities.ACTIVITY_A.isSameActivity(editedA));
+
+        // same name, tags different -> returns false
+        editedA = new ActivityBuilder(TypicalActivities.ACTIVITY_A)
+                .withTags(VALID_TAG_ENTERTAINMENT).build();
+        assertFalse(TypicalActivities.ACTIVITY_A.isSameActivity(editedA));
+
         // different name, all other attributes same -> returns false
         editedA = new ActivityBuilder(TypicalActivities.ACTIVITY_A).withName(VALID_NAME_BOXING).build();
         assertFalse(TypicalActivities.ACTIVITY_A.isSameActivity(editedA));

--- a/src/test/java/hobbylist/model/activity/UniqueActivityListTest.java
+++ b/src/test/java/hobbylist/model/activity/UniqueActivityListTest.java
@@ -41,8 +41,7 @@ public class UniqueActivityListTest {
     @Test
     public void contains_activityWithSameIdentityFieldsInList_returnsTrue() {
         uniqueActivityList.add(TypicalActivities.ACTIVITY_A);
-        Activity editedA = new ActivityBuilder(TypicalActivities.ACTIVITY_A).withDescription(VALID_DESCRIPTION_BOXING)
-                .withTags(VALID_TAG_ENTERTAINMENT)
+        Activity editedA = new ActivityBuilder(TypicalActivities.ACTIVITY_A)
                 .build();
         assertTrue(uniqueActivityList.contains(editedA));
     }


### PR DESCRIPTION
Activities with the same name but different description and tags cannot be added.

Now they can be added.

Closes #54 